### PR TITLE
feat(boot): add boot from flash

### DIFF
--- a/src/arch/armv8m/boot.S
+++ b/src/arch/armv8m/boot.S
@@ -17,11 +17,14 @@
  * PAGE_SIZE.
  */
 .section ".boot", "ax"
-.thumb
-.thumb_func
-.globl _reset_handler
-_reset_handler:
-    b _start
+
+.global _rst_vector_table
+_rst_vector_table:
+    .word 0x30000000
+    .word _start
+    .rept 13
+    .word _exception_handler
+    .endr
 
 .balign PAGE_SIZE
 .global _hypercall_start
@@ -30,6 +33,8 @@ _hypercall_start:
     b _hypercall_handler
 
 .balign PAGE_SIZE
+.thumb
+.thumb_func
 .global _start
 _start:
     /**

--- a/src/arch/armv8m/exceptions.S
+++ b/src/arch/armv8m/exceptions.S
@@ -139,7 +139,7 @@ _hyp_vector_table:
      * reset vector. The reset vector is the address of the reset handler.
      */
     .word 0                     //TODO:ARMV8M should this be initialized with the real MSP value?
-    .word _reset_handler
+    .word _start
     .rept 13
     .word _exception_handler
     .endr


### PR DESCRIPTION
LPC55S69 fetches from the base of the flash memory the reset handler address (i.e., address 0x00000000/0x10000000). With this PR we place a vector table on the base of the hypervisor image that is small enough to not disrupt the location of the hypercall handler which is PAGE_SIZE aligned.